### PR TITLE
Add PPCI compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 - [WebAssembly for the GNU Toolchain](https://sourceware.org/ml/binutils/2017-03/msg00044.html)
 - [faust2 - Functional programming language for signal processing and sound synthesis](http://faust.grame.fr/news/2017/01/13/faust-webassembly.html)
 - [Asterius - A Haskell to WebAssembly compiler](https://github.com/tweag/asterius)
+- [PPCI.wasm - PPCI Can compile wasm to machine code and run it in the Python process](http://ppci.readthedocs.io/en/latest/reference/wasm.html)
 
 ### Non-Web Embeddings
 - [wac - WebAssembly in C (x86)](https://github.com/kanaka/wac)


### PR DESCRIPTION
PPCI is the Pure Python Compiler Infrastructure, an experimental compiler written in Python. It has support for WASM, and can compiler WASM to X86. PPCI supports several architectuires, so its a matter of making the backends more complete to also compile to e.g. ARM. Work in progress, but worth mentioning IMO.

Disclaimer: I am not the main author of PPCI, but have contributed to adding support for WASM.